### PR TITLE
hr_attendance_missing: use named parameters to pass timerange to function

### DIFF
--- a/hr_attendance_missing/wizard/select_period.py
+++ b/hr_attendance_missing/wizard/select_period.py
@@ -27,4 +27,6 @@ class HRAttendanceMissingSelectPeriod(models.TransientModel):
     def action_create_missing_attendances(self):
         active_ids = self.env.context["active_ids"]
         employees = self.env["hr.employee"].browse(active_ids)
-        return employees._create_missing_attendances(self.date_from, self.date_to)
+        return employees._create_missing_attendances(
+            date_from=self.date_from, date_to=self.date_to
+        )


### PR DESCRIPTION
This PR makes the functionality of the wizard to choose the time range passing the correct parameters. Without this change, the wizard doesn't work.