### PR TITLE
Exclude attendances with missing check_out

### DIFF
--- a/hr_attendance_missing/models/hr_employee.py
+++ b/hr_attendance_missing/models/hr_employee.py
@@ -34,9 +34,13 @@ class HrEmployee(models.Model):
         missing_attendances = []
         for employee in self:
 
-            # Get attendances
+            # Get attendances - excluding the ones with check_out missing
             attendances = self.env["hr.attendance"].search(
-                [("employee_id", "=", employee.id), ("check_in", ">=", date_from)]
+                [
+                    ("employee_id", "=", employee.id),
+                    ("check_in", ">=", date_from),
+                    ("check_out", "!=", False),
+                ]
             )
             attendance_dates = attendances.mapped("check_in") + attendances.mapped(
                 "check_out"


### PR DESCRIPTION
When an employee misses to check out and the attendance filler wants to do its job, it would fall on his face. We need to exclude attendances without a check_out.

Fixes:

```
Traceback (most recent call last):
  File "/opt/odoo/bin/odoo/tools/safe_eval.py", line 362, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(1308,)", line 1, in <module>
  File "/opt/odoo/addons/hr_attendance_missing/models/hr_employee.py", line 17, in run_create_missing_attendances
    employees._create_missing_attendances(logging=logging)
  File "/opt/odoo/addons/hr_attendance_missing/models/hr_employee.py", line 42, in _create_missing_attendances
    attendance_dates = [dt.date() for dt in attendance_dates]
  File "/opt/odoo/addons/hr_attendance_missing/models/hr_employee.py", line 42, in <listcomp>
    attendance_dates = [dt.date() for dt in attendance_dates]
AttributeError: 'bool' object has no attribute 'date'
```