### PR TITLE
[FIX] hr_leave: return empty recordset for public holidays

### DIFF
--- a/hr_holidays_working_time/models/hr_leave.py
+++ b/hr_holidays_working_time/models/hr_leave.py
@@ -98,7 +98,7 @@ class HrLeave(models.Model):
         """
         Overwrite method to allow leaves on public holiday.
         """
-        return False
+        return self.env['hr.leave']
 
     # @api.model_create_multi
     # def create(self, vals_list):


### PR DESCRIPTION
Fixes AttributeError when payroll modules call .filtered() on return value from _get_leaves_on_public_holiday method.